### PR TITLE
Remove References to POC, Allow caching of css and javascript

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ The following environment variables are required by the application container. V
 | COOKIE_PASSWORD                       | Redis cookie password      | yes      |                       |                             |
 | API_GATEWAY                           | Url of service API Gateway | no       | http://localhost:3001 |                             |
 | SESSION_TIMEOUT_IN_MINUTES            | Redis session timeout      | no       | 30                    |                             |
+| STATIC_CACHE_TIMEOUT_IN_MILLIS        | static file cache timeout  | no       | 54000 (15 minutes)    |                             |
 | REST_CLIENT_TIMEOUT_IN_MILLIS         | Rest client timout         | no       | 5000                  |                             |
 
 # How to run tests

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 appVersion: "1.0"
-description: A Helm chart to deploy the FFC POC Service sample application to Kubernetes
+description: A Helm chart to deploy the FFC Demo Service sample application to Kubernetes
 name: helm
 # this version is automatically updated in the build pipline
 version: 1.0.0

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -50,6 +50,8 @@ spec:
           value: {{ .Values.container.apiGatewayUrl }}
         - name: REST_CLIENT_TIMEOUT_IN_MILLIS
           value: {{ .Values.container.restClientTimeoutMillis | quote }}
+        - name: STATIC_CACHE_TIMEOUT_IN_MILLIS
+          value: {{ .Values.container.staticCacheTimeoutMillis | quote }}
         ports:
         - name: http
           containerPort: 3000

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -22,7 +22,7 @@ container:
   apiGatewayUrl: http://ffc-demo-api-gateway.default
   restartPolicy: Always
   restClientTimeoutMillis: 20000
-  
+  staticCacheTimeoutMillis: 54000
 ingress:
   serviceName: ffc-demo-web
   endPoint: ffc-demo

--- a/server/config.js
+++ b/server/config.js
@@ -9,6 +9,7 @@ const schema = {
   redisPort: joi.number().default(6379),
   cookiePassword: joi.string().required(),
   sessionTimeoutMinutes: joi.number().default(30),
+  staticCacheTimeoutMillis: joi.number().default(15 * 60 * 1000),
   apiGateway: joi.string().uri().default('http://localhost:3001'),
   restClientTimeoutMillis: joi.number().default(20000)
 }
@@ -23,7 +24,8 @@ const config = {
   cookiePassword: process.env.COOKIE_PASSWORD,
   sessionTimeoutMinutes: process.env.SESSION_TIMEOUT_IN_MINUTES,
   apiGateway: process.env.API_GATEWAY,
-  restClientTimeoutMillis: process.env.REST_CLIENT_TIMEOUT_IN_MILLIS
+  restClientTimeoutMillis: process.env.REST_CLIENT_TIMEOUT_IN_MILLIS,
+  staticCacheTimeoutMillis: process.env.STATIC_CACHE_TIMEOUT_IN_MILLIS
 }
 
 // Validate config

--- a/server/plugins/views.js
+++ b/server/plugins/views.js
@@ -36,8 +36,8 @@ module.exports = {
     context: {
       appVersion: pkg.version,
       assetPath: '/assets',
-      serviceName: 'FFC POC Service',
-      pageTitle: 'FFC POC Service - GOV.UK',
+      serviceName: 'FFC Demo Service',
+      pageTitle: 'FFC Demo Service - GOV.UK',
       analyticsAccount: analyticsAccount
     }
   }

--- a/server/routes/public.js
+++ b/server/routes/public.js
@@ -1,9 +1,15 @@
+const config = require('../config')
+
 module.exports = [{
   method: 'GET',
   path: '/robots.txt',
   options: {
     handler: {
       file: 'server/public/static/robots.txt'
+    },
+    cache: {
+      expiresIn: config.staticCacheTimeoutMillis,
+      privacy: 'private'
     }
   }
 }, {
@@ -12,6 +18,10 @@ module.exports = [{
   options: {
     handler: {
       file: 'node_modules/govuk-frontend/all.js'
+    },
+    cache: {
+      expiresIn: config.staticCacheTimeoutMillis,
+      privacy: 'private'
     }
   }
 }, {
@@ -26,6 +36,10 @@ module.exports = [{
           'node_modules/govuk-frontend/assets'
         ]
       }
+    },
+    cache: {
+      expiresIn: config.staticCacheTimeoutMillis,
+      privacy: 'private'
     }
   }
 }]

--- a/server/views/service-unavailable.njk
+++ b/server/views/service-unavailable.njk
@@ -13,7 +13,7 @@
         We saved your answers. They will be available for 30 days.
       </p>
       <p class="govuk-body"><a class="govuk-link" href="#">
-        Contact the FFC POC Service Helpline</a> if you need to make changes to your claim or speak to someone about your claim.
+        Contact the FFC Demo Service Helpline</a> if you need to make changes to your claim or speak to someone about your claim.
       </p>
     </div>
   </div>


### PR DESCRIPTION
Remove POC from header and call line.
Add default of 15 minute caching for static files to prevent reload on every page.