### PR TITLE
Additional Ingress and Name Settings for deployment to techtonic cluster

### DIFF
--- a/helm/templates/ingress-alb.yaml
+++ b/helm/templates/ingress-alb.yaml
@@ -2,10 +2,11 @@
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: {{ .Values.ingress.serviceName }}
+  name: {{ .Values.name }}
   annotations:
     kubernetes.io/ingress.class: alb
     alb.ingress.kubernetes.io/scheme: internal
+    alb.ingress.kubernetes.io/security-groups: {{ .Values.ingress.alb.securityGroups}}
     alb.ingress.kubernetes.io/certificate-arn: {{ .Values.ingress.alb.arn}}
     alb.ingress.kubernetes.io/tags: {{ .Values.ingress.alb.tags }}
     external-dns.alpha.kubernetes.io/aws-zone-type-private: "true"
@@ -20,6 +21,6 @@ spec:
       paths:
       - path: /*
         backend:
-          serviceName: {{ .Values.ingress.serviceName }}
+          serviceName: {{ .Values.name }}
           servicePort: {{ .Values.service.port }}
 {{- end }}

--- a/helm/templates/ingress.yaml
+++ b/helm/templates/ingress.yaml
@@ -16,10 +16,10 @@ metadata:
     nginx.ingress.kubernetes.io/session-cookie-expires: "172800"
     nginx.ingress.kubernetes.io/session-cookie-max-age: "172800"
     nginx.ingress.kubernetes.io/configuration-snippet: |
-      proxy_set_header l5d-dst-override {{.Values.ingress.serviceName }}.default.svc.cluster.local:{{ .Values.service.port }};
+      proxy_set_header l5d-dst-override {{.Values.name }}.default.svc.cluster.local:{{ .Values.service.port }};
       proxy_hide_header l5d-remote-ip;
       proxy_hide_header l5d-server-id;
-  name: {{ .Values.ingress.serviceName }}
+  name: {{ .Values.name }}
 spec:
   rules:
 {{- if .Values.ingress.endpoint }}
@@ -31,6 +31,6 @@ spec:
       paths:
       - path: /?(.*)
         backend:
-          serviceName: {{ .Values.ingress.serviceName }}
+          serviceName: {{ .Values.name }}
           servicePort: {{ .Values.service.port }}
 {{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -24,7 +24,6 @@ container:
   restClientTimeoutMillis: 20000
   staticCacheTimeoutMillis: 54000
 ingress:
-  serviceName: ffc-demo-web
   endPoint: ffc-demo
   server: vividcloudsolutions.co.uk
 replicas: 1


### PR DESCRIPTION
ALB requires the name, service name and ingress end point to be the same.
These changes simplify the configuration and add the security groups annotation

https://eaflood.atlassian.net/browse/PSD-124