### PR TITLE
Update default API Gateway URL

### DIFF
--- a/helm/ffc-demo-web/jenkins-aws.yaml
+++ b/helm/ffc-demo-web/jenkins-aws.yaml
@@ -5,9 +5,8 @@ service:
   type: NodePort
 container:
   allowPrivilegeEscalation: true
+  apiGatewayUrl: http://ffc-demo-api-gateway.ffc-demo
   imagePullPolicy: Always
 ingress:
   endPoint: ffc-demo-web
   server: ffc.aws-int.defra.cloud
-apiGatewayUrl: http://ffc-demo-api-gateway.ffc-demo
-  

--- a/helm/ffc-demo-web/jenkins-aws.yaml
+++ b/helm/ffc-demo-web/jenkins-aws.yaml
@@ -5,7 +5,6 @@ service:
   type: NodePort
 container:
   allowPrivilegeEscalation: true
-  apiGatewayUrl: http://ffc-demo-api-gateway.ffc-demo
   imagePullPolicy: Always
 ingress:
   endPoint: ffc-demo-web

--- a/helm/ffc-demo-web/jenkins-aws.yaml
+++ b/helm/ffc-demo-web/jenkins-aws.yaml
@@ -5,6 +5,7 @@ service:
   type: NodePort
 container:
   allowPrivilegeEscalation: true
+  apiGatewayUrl: http://ffc-demo-api-gateway.ffc-demo
   imagePullPolicy: Always
 ingress:
   endPoint: ffc-demo-web

--- a/helm/ffc-demo-web/values.yaml
+++ b/helm/ffc-demo-web/values.yaml
@@ -2,7 +2,7 @@ environment: development
 image: ffc-demo-web
 name: ffc-demo-web
 auth:
-imagePullSecret: 
+imagePullSecret:
 service:
   port: 80
   type: ClusterIP

--- a/helm/ffc-demo-web/values.yaml
+++ b/helm/ffc-demo-web/values.yaml
@@ -19,7 +19,7 @@ container:
   runAsUser: 1000
   readOnlyRootFilesystem: true
   allowPrivilegeEscalation: false
-  apiGatewayUrl: http://ffc-demo-api-gateway.default
+  apiGatewayUrl: http://ffc-demo-api-gateway.ffc-demo
   restartPolicy: Always
   restClientTimeoutMillis: 20000
   staticCacheTimeoutMillis: 54000

--- a/helm/ffc-demo-web/values.yaml
+++ b/helm/ffc-demo-web/values.yaml
@@ -19,7 +19,7 @@ container:
   runAsUser: 1000
   readOnlyRootFilesystem: true
   allowPrivilegeEscalation: false
-  apiGatewayUrl: http://ffc-demo-api-gateway.ffc-demo
+  apiGatewayUrl: http://ffc-demo-api-gateway.default
   restartPolicy: Always
   restClientTimeoutMillis: 20000
   staticCacheTimeoutMillis: 54000


### PR DESCRIPTION
Assume API Gateway will be in the `ffc-demo` namespace by default.