### PR TITLE
Roll pods on every deployment from build pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,8 +36,6 @@ node {
             string(credentialsId: 'albArn', variable: 'albArn')
           ]) {
 
-          def timestamp = new Date().getTime()
-
           def helmValues = [
             /name="ffc-demo-$containerTag"/,
             /ingress.server="$ingressServer"/,
@@ -45,7 +43,7 @@ node {
             /ingress.alb.tags="$albTags"/,
             /ingress.alb.arn="$albArn"/,
             /ingress.alb.securityGroups="$albSecurityGroups"/,
-            /redeployOnChange="$timestamp"/
+            /redeployOnChange="${currentBuild.startTimeInMillis}"/
           ].concat(',')
 
           def extraCommands = [

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('defra-library@0.0.3')
+@Library('defra-library@psd-231-stop-recreating-pods')
 import uk.gov.defra.ffc.DefraUtils
 def defraUtils = new DefraUtils()
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,7 +35,24 @@ node {
             string(credentialsId: 'albSecurityGroups', variable: 'albSecurityGroups'),
             string(credentialsId: 'albArn', variable: 'albArn')
           ]) {
-          def extraCommands = "--values ./helm/ffc-demo-web/jenkins-aws.yaml --set name=ffc-demo-$containerTag,ingress.server=$ingressServer,ingress.endpoint=ffc-demo-$containerTag,ingress.alb.tags=\"$albTags\",ingress.alb.arn=\"$albArn\",ingress.alb.securityGroups=\"$albSecurityGroups\""
+
+          def timestamp = new Date().getTime()
+
+          def helmValues = [
+            /name="ffc-demo-$containerTag"/,
+            /ingress.server="$ingressServer"/,
+            /ingress.endpoint="ffc-demo-$containerTag"/,
+            /ingress.alb.tags="$albTags"/,
+            /ingress.alb.arn="$albArn"/,
+            /ingress.alb.securityGroups="$albSecurityGroups"/,
+            /redeployOnChange="$timestamp"/
+          ].concat(',')
+
+          def extraCommands = [
+            "--values ./helm/ffc-demo-web/jenkins-aws.yaml",
+            "--set $helmValues"
+          ].concat(' ')
+
           defraUtils.deployChart(kubeCredsId, registry, imageName, containerTag, extraCommands)
           echo "Build available for review at https://ffc-demo-$containerTag.$ingressServer"
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,7 +37,7 @@ node {
           ]) {
 
           def helmValues = [
-            /container.redeployOnChange="${currentBuild.startTimeInMillis}"/,
+            /container.redeployOnChange="$pr-$BUILD_NUMBER"/,
             /ingress.alb.tags="$albTags"/,
             /ingress.alb.arn="$albArn"/,
             /ingress.alb.securityGroups="$albSecurityGroups"/,

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('defra-library@psd-231-stop-recreating-pods')
+@Library('defra-library@0.0.4')
 import uk.gov.defra.ffc.DefraUtils
 def defraUtils = new DefraUtils()
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,13 +37,13 @@ node {
           ]) {
 
           def helmValues = [
-            /name="ffc-demo-$containerTag"/,
-            /ingress.server="$ingressServer"/,
-            /ingress.endpoint="ffc-demo-$containerTag"/,
+            /container.redeployOnChange="${currentBuild.startTimeInMillis}"/
             /ingress.alb.tags="$albTags"/,
             /ingress.alb.arn="$albArn"/,
             /ingress.alb.securityGroups="$albSecurityGroups"/,
-            /redeployOnChange="${currentBuild.startTimeInMillis}"/
+            /ingress.endpoint="ffc-demo-$containerTag"/,
+            /ingress.server="$ingressServer"/,
+            /name="ffc-demo-$containerTag"/,
           ].join(',')
 
           def extraCommands = [

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -44,12 +44,12 @@ node {
             /ingress.alb.arn="$albArn"/,
             /ingress.alb.securityGroups="$albSecurityGroups"/,
             /redeployOnChange="${currentBuild.startTimeInMillis}"/
-          ].concat(',')
+          ].join(',')
 
           def extraCommands = [
             "--values ./helm/ffc-demo-web/jenkins-aws.yaml",
             "--set $helmValues"
-          ].concat(' ')
+          ].join(' ')
 
           defraUtils.deployChart(kubeCredsId, registry, imageName, containerTag, extraCommands)
           echo "Build available for review at https://ffc-demo-$containerTag.$ingressServer"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,13 +37,13 @@ node {
           ]) {
 
           def helmValues = [
-            /container.redeployOnChange="${currentBuild.startTimeInMillis}"/
+            /container.redeployOnChange="${currentBuild.startTimeInMillis}"/,
             /ingress.alb.tags="$albTags"/,
             /ingress.alb.arn="$albArn"/,
             /ingress.alb.securityGroups="$albSecurityGroups"/,
             /ingress.endpoint="ffc-demo-$containerTag"/,
             /ingress.server="$ingressServer"/,
-            /name="ffc-demo-$containerTag"/,
+            /name="ffc-demo-$containerTag"/
           ].join(',')
 
           def extraCommands = [

--- a/helm/ffc-demo-web/templates/deployment.yaml
+++ b/helm/ffc-demo-web/templates/deployment.yaml
@@ -11,7 +11,7 @@ spec:
       labels:
         app: {{ .Values.name }}
       annotations:
-        redeployOnChange: "{{ .Values.container.redeployOnChange }}"
+        forceRedeploy: {{ .Values.container.redeployOnChange | quote }}
     spec:
       restartPolicy: {{ .Values.container.restartPolicy }}
       {{- if .Values.imagePullSecret }}

--- a/helm/ffc-demo-web/templates/deployment.yaml
+++ b/helm/ffc-demo-web/templates/deployment.yaml
@@ -11,7 +11,7 @@ spec:
       labels:
         app: {{ .Values.name }}
       annotations:
-        forceRedeploy: {{ .Values.container.redeployOnChange | quote }}
+        redeployOnChange: {{ .Values.container.redeployOnChange | quote }}
     spec:
       restartPolicy: {{ .Values.container.restartPolicy }}
       {{- if .Values.imagePullSecret }}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/PSD-231

Use a unique value for the redeployOnChange annotation to trigger pod redeployment in Kubernetes on each deployment from the Jenkins build pipeline.