### PR TITLE
Demo service needs a PaaS cache

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -60,6 +60,7 @@ node {
 
           def helmValues = [
             /container.redeployOnChange="$pr-$BUILD_NUMBER"/,
+            /container.redisPartition="ffc-demo-$containerTag"/,
             /cookiePassword="$cookiePassword"/,
             /ingress.alb.tags="$albTags"/,
             /ingress.alb.arn="$albArn"/,

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -60,6 +60,7 @@ node {
 
           def helmValues = [
             /container.redeployOnChange="$pr-$BUILD_NUMBER"/,
+            /container.redisHostname="$REDIS_HOSTNAME"/,
             /container.redisPartition="ffc-demo-$containerTag"/,
             /cookiePassword="$cookiePassword"/,
             /ingress.alb.tags="$albTags"/,

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Additional Docker Compose files are provided for scenarios such as linking to ot
 
 Link to other services:
 ```
-docker-compose -f docker-compose.yaml -f docker-compose.link.yaml up
+docker-compose -f docker-compose.yaml -f docker-compose.override.yaml -f docker-compose.link.yaml up
 ```
 
 ### Deploy to Kubernetes

--- a/app/config.js
+++ b/app/config.js
@@ -4,9 +4,10 @@ const Joi = require('@hapi/joi')
 const schema = Joi.object({
   port: Joi.number().default(3000),
   env: Joi.string().valid('development', 'test', 'production').default('development'),
-  cacheName: Joi.string().default('redisCache'),
+  cacheName: Joi.string(),
   redisHost: Joi.string().default('localhost'),
   redisPort: Joi.number().default(6379),
+  redisPartition: Joi.string().default('ffc-demo'),
   cookiePassword: Joi.string().required(),
   sessionTimeoutMinutes: Joi.number().default(30),
   staticCacheTimeoutMillis: Joi.number().default(15 * 60 * 1000),
@@ -18,7 +19,8 @@ const schema = Joi.object({
 const config = {
   port: process.env.PORT,
   env: process.env.NODE_ENV,
-  cacheName: process.env.CACHE_NAME,
+  cacheName: 'redisCache',
+  redisPartition: process.env.REDIS_PARTITION,
   redisHost: process.env.REDIS_HOSTNAME,
   redisPort: process.env.REDIS_PORT,
   cookiePassword: process.env.COOKIE_PASSWORD,

--- a/app/server.js
+++ b/app/server.js
@@ -11,9 +11,6 @@ async function createServer () {
         options: {
           abortEarly: false
         }
-      // },
-      // cache: {
-      //   otherwise: 'no-cache, must-revalidate, max-age=0, no-store'
       }
     },
     cache: [{
@@ -23,7 +20,7 @@ async function createServer () {
         options: {
           host: config.redisHost,
           port: config.redisPort,
-          partition: 'mine-support'
+          partition: config.redisPartition
         }
       }
     }]

--- a/docker-compose.link.yaml
+++ b/docker-compose.link.yaml
@@ -6,21 +6,9 @@ version: '3.7'
 
 services:
   ffc-demo-web:
-    build:
-      target: development
-    image: ffc-demo-web-development
     networks:
       - default
       - ffc-demo
-    ports:
-      - "3000:3000"
-    volumes:
-      - ./.git/:/home/node/.git/ # Git is required by Jest file watcher
-      - ./app/:/home/node/app/
-      - ./test/:/home/node/test/
-      - ./test-output/:/home/node/test-output/
-      - ./jest.config.js:/home/node/jest.config.js
-      - ./package.json:/home/node/package.json
 
 networks:
   ffc-demo:

--- a/docker-compose.override.yaml
+++ b/docker-compose.override.yaml
@@ -27,3 +27,6 @@ services:
       - redis_data:/data
     ports:
       - "6379:6379"
+
+volumes:
+  redis_data:

--- a/docker-compose.override.yaml
+++ b/docker-compose.override.yaml
@@ -8,6 +8,8 @@ services:
     build:
       target: development
     image: ffc-demo-web-development
+    depends_on:
+      - redis
     ports:
       - "3000:3000"
       - "9229:9229"
@@ -20,5 +22,8 @@ services:
       - ./package.json:/home/node/package.json
 
   redis:
+    image: redis:4.0.14
+    volumes:
+      - redis_data:/data
     ports:
       - "6379:6379"

--- a/docker-compose.test.yaml
+++ b/docker-compose.test.yaml
@@ -10,6 +10,8 @@ services:
       target: development
     image: ffc-demo-web-development
     command: npm test
+    environment:
+      NODE_ENV: test
     volumes:
       - ./test/:/home/node/test/
       - ./test-output/:/home/node/test-output/

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,17 +8,10 @@ services:
       args:
         REGISTRY: ${DOCKER_REGISTRY:-562955126301.dkr.ecr.eu-west-2.amazonaws.com}
     image: ffc-demo-web
-    depends_on:
-      - redis
     environment:
       API_GATEWAY: http://ffc-demo-api-gateway:3001
       COOKIE_PASSWORD: cookiecookiecookiecookiecookiecookie
       REDIS_HOSTNAME: redis
-
-  redis:
-    image: redis:4.0.14
-    volumes:
-      - redis_data:/data
 
 volumes:
   redis_data:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,7 +16,7 @@ services:
       REDIS_HOSTNAME: redis
 
   redis:
-    image: redis
+    image: redis:4.0.14
     volumes:
       - redis_data:/data
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -12,6 +12,3 @@ services:
       API_GATEWAY: http://ffc-demo-api-gateway:3001
       COOKIE_PASSWORD: cookiecookiecookiecookiecookiecookie
       REDIS_HOSTNAME: redis
-
-volumes:
-  redis_data:

--- a/helm/ffc-demo-web/development-values.yaml
+++ b/helm/ffc-demo-web/development-values.yaml
@@ -4,7 +4,7 @@ container:
   args: ["node app"]
   allowPrivilegeEscalation: true
   readOnlyRootFilesystem: false
-  redisname: ffc-demo-web-redis-headless.ffc-demo.svc.cluster.local
+  redisHostname: ffc-demo-web-redis-headless.ffc-demo.svc.cluster.local
 ingress:
   endpoint:
 replicaCount: 1

--- a/helm/ffc-demo-web/jenkins-aws.yaml
+++ b/helm/ffc-demo-web/jenkins-aws.yaml
@@ -10,4 +10,4 @@ container:
   imagePullPolicy: Always
 ingress:
   endPoint: ffc-demo-web
-  server: ffc.aws-int.defra.cloud
+  server: dev-ffc.aws-int.defra.cloud

--- a/helm/ffc-demo-web/jenkins-aws.yaml
+++ b/helm/ffc-demo-web/jenkins-aws.yaml
@@ -10,4 +10,4 @@ container:
   imagePullPolicy: Always
 ingress:
   endPoint: ffc-demo-web
-  server: dev-ffc.aws-int.defra.cloud
+  server: ffc-dev.aws-int.defra.cloud

--- a/helm/ffc-demo-web/templates/deployment.yaml
+++ b/helm/ffc-demo-web/templates/deployment.yaml
@@ -47,7 +47,9 @@ spec:
         - name: COOKIE_PASSWORD
           value: {{ quote .Values.cookiePassword }}
         - name: REDIS_HOSTNAME
-          value: {{ quote .Values.container.redisname }}
+          value: {{ quote .Values.container.redisHostname }}
+        - name: REDIS_PARTITION
+          value: {{ quote .Values.container.redisPartition }}
         - name: API_GATEWAY
           value: {{ quote .Values.container.apiGatewayUrl }}
         - name: REST_CLIENT_TIMEOUT_IN_MILLIS

--- a/helm/ffc-demo-web/values.yaml
+++ b/helm/ffc-demo-web/values.yaml
@@ -9,7 +9,8 @@ service:
   type: ClusterIP
 
 container:
-  redisname: redis-redis-ha.default
+  redisHostname: redis-redis-ha.default
+  redisPartition: ffc-demo
   priorityClassName: low
   imagePullPolicy: IfNotPresent
   redeployOnChange: update this field to force a change

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ffc-demo-web",
   "description": "Digital service mock to claim public money in the event property subsides into mine shaft.",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "homepage": "https://github.com/DEFRA/ffc-demo-web",
   "repository": {
     "type": "git",


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/PSD-545

The Redis internal to the cluster will be replaced with a cache PaaS
solution, namely Elasticache