### PR TITLE
Resolve deployment issue with label selectors

### DIFF
--- a/helm/ffc-demo-web/templates/deployment.yaml
+++ b/helm/ffc-demo-web/templates/deployment.yaml
@@ -9,6 +9,9 @@ spec:
   replicas: {{ .Values.replicas }}
   minReadySeconds: {{ .Values.minReadySeconds }}
   strategy: {}
+  selector:
+    app.kubernetes.io/name: {{ quote .Values.name }}
+    app: {{ quote .Values.namespace }}
   template:
     metadata:
       labels: {{ include "ffc-demo.labels" . | trimSuffix "\n" | indent 6 }}

--- a/helm/ffc-demo-web/templates/deployment.yaml
+++ b/helm/ffc-demo-web/templates/deployment.yaml
@@ -10,8 +10,9 @@ spec:
   minReadySeconds: {{ .Values.minReadySeconds }}
   strategy: {}
   selector:
-    app.kubernetes.io/name: {{ quote .Values.name }}
-    app: {{ quote .Values.namespace }}
+    matchLabels:
+      app.kubernetes.io/name: {{ quote .Values.name }}
+      app: {{ quote .Values.namespace }}
   template:
     metadata:
       labels: {{ include "ffc-demo.labels" . | trimSuffix "\n" | indent 6 }}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ffc-demo-web",
   "description": "Digital service mock to claim public money in the event property subsides into mine shaft.",
-  "version": "1.0.27",
+  "version": "1.0.28",
   "homepage": "https://github.com/DEFRA/ffc-demo-web",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Now the values of our labels (rightly) change with each deployment, the deployment loses which pods it's responsible for.  To resolve this we need to add a selector to the deployment.yaml file which is matched by constant labels only.