### PR TITLE
295886: Added ffc-demo-web-pre1 variable group ref

### DIFF
--- a/.azuredevops/build.yaml
+++ b/.azuredevops/build.yaml
@@ -61,6 +61,7 @@ extends:
         - ffc-demo-web-snd3
         - ffc-demo-web-dev1
         - ffc-demo-web-tst1
+        - ffc-demo-web-pre1
       variables:
         - ffc-demo-web-APPINSIGHTS-CONNECTIONSTRING
         - ffc-demo-web-COOKIE-PASSWORD

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ffc-demo-web",
-  "version": "4.32.18",
+  "version": "4.32.19",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ffc-demo-web",
-      "version": "4.32.18",
+      "version": "4.32.19",
       "license": "OGL-UK-3.0",
       "dependencies": {
         "@hapi/catbox-redis": "6.0.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ffc-demo-web",
   "description": "Digital service mock to claim public money in the event property subsides into mine shaft.",
-  "version": "4.32.18",
+  "version": "4.32.19",
   "homepage": "https://github.com/DEFRA/ffc-demo-web",
   "repository": {
     "type": "git",


### PR DESCRIPTION
As part of the trial ADP PRE deployment we noticed the variable group refs were missing from the application pipeline. This PR adds the variable group reference.