### PR TITLE
306948: Added example storage account in ffc-demo-web helm chart

### DIFF
--- a/helm/ffc-demo-web-infra/templates/storage-account.yaml
+++ b/helm/ffc-demo-web-infra/templates/storage-account.yaml
@@ -1,0 +1,1 @@
+{{- include "adp-aso-helm-library.storage-account" . -}}

--- a/helm/ffc-demo-web-infra/values.yaml
+++ b/helm/ffc-demo-web-infra/values.yaml
@@ -7,3 +7,17 @@ namespaceTopics:
   - name: claim-notify
     roleAssignments:
       - roleName: 'TopicSender'
+
+storageAccounts:
+  - name: ffcdemoadpinfst1401
+    blobContainers:  
+      - name: container-01
+        roleAssignments:
+          - roleName: 'BlobDataContributor' 
+      - name: container-02
+        roleAssignments:
+          - roleName: 'BlobDataReader'   
+    tables:  
+      - name: table01  
+        roleAssignments:
+          - roleName: 'TableDataContributor'       

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ffc-demo-web",
   "description": "Digital service mock to claim public money in the event property subsides into mine shaft.",
-  "version": "4.32.28",
+  "version": "4.32.29",
   "homepage": "https://github.com/DEFRA/ffc-demo-web",
   "repository": {
     "type": "git",


### PR DESCRIPTION
 Added example storage account in ffc-demo-web helm infra chart to test end to end Storage account and private endpoint creation.