### PR TITLE
Adding variableGroup support for postDeployTest

### DIFF
--- a/.azuredevops/build.yaml
+++ b/.azuredevops/build.yaml
@@ -66,4 +66,3 @@ extends:
       filetype: "yaml"
       variableGroups:
         - ffc-demo-web-<environment>
-

--- a/.azuredevops/build.yaml
+++ b/.azuredevops/build.yaml
@@ -66,3 +66,4 @@ extends:
       filetype: "yaml"
       variableGroups:
         - ffc-demo-web-<environment>
+

--- a/.azuredevops/build.yaml
+++ b/.azuredevops/build.yaml
@@ -35,8 +35,9 @@ resources:
       name: DEFRA/adp-pipeline-common
       endpoint: DEFRA
       type: github
-      ref: refs/tags/1.0.0-latest
-            
+      #ref: refs/tags/1.0.0-latest
+      ref: feature/PL-140
+
 extends:
   template: /pipelines/common-app-build.yaml@DEFRA-ADPPipelineCommon
   parameters:
@@ -46,7 +47,7 @@ extends:
     deployConfigOnly: ${{ parameters.deployConfigOnly }}
     includePlatformEnvs: false
     appBuildConfig:
-      appFrameworkType: "nodejs"  
+      appFrameworkType: "nodejs"
       projectPath: "./package.json"
       manifestPath: "./package.json"
       imageRepoName: "ffc-demo-web"
@@ -57,12 +58,12 @@ extends:
         envToTest: snd4
         testsToRun: 'acceptance;integration;contract'
         testEnvs:
-          acceptanceTests: 
+          acceptanceTests:
             - env: snd4
               tags: '@demotag'
     appDeployConfig:
       filepath: "./appConfig"
-      filetype: "yaml"    
-      variableGroups: 
+      filetype: "yaml"
+      variableGroups:
         - ffc-demo-web-<environment>
 

--- a/docker-compose.contract.test.yaml
+++ b/docker-compose.contract.test.yaml
@@ -14,6 +14,7 @@ services:
       PACT_BROKER_URL: ${PACT_BROKER_URL}
       PACT_BROKER_USERNAME: ${PACT_BROKER_USERNAME}
       PACT_BROKER_PASSWORD: ${PACT_BROKER_PASSWORD}
+      MY_ENV_VAR: ${ffc-demo-web-APPINSIGHTS-CONNECTIONSTRING}
     volumes:
       - ./test/asb-helper.js:/home/node/test/asb-helper.js
       - ./package.json:/home/node/package.json

--- a/docker-compose.contract.test.yaml
+++ b/docker-compose.contract.test.yaml
@@ -14,7 +14,7 @@ services:
       PACT_BROKER_URL: ${PACT_BROKER_URL}
       PACT_BROKER_USERNAME: ${PACT_BROKER_USERNAME}
       PACT_BROKER_PASSWORD: ${PACT_BROKER_PASSWORD}
-      MY_ENV_VAR: ${MY_ENV_VAR}
+      ffc_demo_web_TEST_VAR: ${ffc-demo-web-TEST-VAR}
     volumes:
       - ./test/asb-helper.js:/home/node/test/asb-helper.js
       - ./package.json:/home/node/package.json

--- a/docker-compose.contract.test.yaml
+++ b/docker-compose.contract.test.yaml
@@ -14,7 +14,7 @@ services:
       PACT_BROKER_URL: ${PACT_BROKER_URL}
       PACT_BROKER_USERNAME: ${PACT_BROKER_USERNAME}
       PACT_BROKER_PASSWORD: ${PACT_BROKER_PASSWORD}
-      ffc_demo_web_TEST_VAR: ${ffc-demo-web-TEST-VAR}
+      ffc_demo_web_APPINSIGHTS_CONNECTIONSTRING: ${ffc-demo-web-APPINSIGHTS-CONNECTIONSTRING}
     volumes:
       - ./test/asb-helper.js:/home/node/test/asb-helper.js
       - ./package.json:/home/node/package.json

--- a/docker-compose.contract.test.yaml
+++ b/docker-compose.contract.test.yaml
@@ -14,7 +14,7 @@ services:
       PACT_BROKER_URL: ${PACT_BROKER_URL}
       PACT_BROKER_USERNAME: ${PACT_BROKER_USERNAME}
       PACT_BROKER_PASSWORD: ${PACT_BROKER_PASSWORD}
-      MY_ENV_VAR: ${ffc-demo-web-TEST-VAR}
+      MY_ENV_VAR: ${MY_ENV_VAR}
     volumes:
       - ./test/asb-helper.js:/home/node/test/asb-helper.js
       - ./package.json:/home/node/package.json

--- a/docker-compose.contract.test.yaml
+++ b/docker-compose.contract.test.yaml
@@ -14,7 +14,7 @@ services:
       PACT_BROKER_URL: ${PACT_BROKER_URL}
       PACT_BROKER_USERNAME: ${PACT_BROKER_USERNAME}
       PACT_BROKER_PASSWORD: ${PACT_BROKER_PASSWORD}
-      MY_ENV_VAR: ${ffc-demo-web-APPINSIGHTS-CONNECTIONSTRING}
+      MY_ENV_VAR: ${ffc-demo-web-TEST-VAR}
     volumes:
       - ./test/asb-helper.js:/home/node/test/asb-helper.js
       - ./package.json:/home/node/package.json

--- a/docker-compose.test.yaml
+++ b/docker-compose.test.yaml
@@ -14,7 +14,7 @@ services:
       PACT_BROKER_URL: ${PACT_BROKER_URL}
       PACT_BROKER_USERNAME: ${PACT_BROKER_USERNAME}
       PACT_BROKER_PASSWORD: ${PACT_BROKER_PASSWORD}
-      ffc-demo-web-TEST-VAR: ${ffc-demo-web-TEST-VAR}
+      ffc_demo_web_TEST_VAR: ${ffc-demo-web-TEST-VAR}
     volumes:
       - ./test/integration:/home/node/test/integration
       - ./test/unit:/home/node/test/unit

--- a/docker-compose.test.yaml
+++ b/docker-compose.test.yaml
@@ -14,7 +14,7 @@ services:
       PACT_BROKER_URL: ${PACT_BROKER_URL}
       PACT_BROKER_USERNAME: ${PACT_BROKER_USERNAME}
       PACT_BROKER_PASSWORD: ${PACT_BROKER_PASSWORD}
-      ffc_demo_web_TEST_VAR: ${ffc-demo-web-TEST-VAR}
+      ffc_demo_web_APPINSIGHTS_CONNECTIONSTRING: ${ffc-demo-web-APPINSIGHTS-CONNECTIONSTRING}
     volumes:
       - ./test/integration:/home/node/test/integration
       - ./test/unit:/home/node/test/unit

--- a/docker-compose.test.yaml
+++ b/docker-compose.test.yaml
@@ -14,6 +14,7 @@ services:
       PACT_BROKER_URL: ${PACT_BROKER_URL}
       PACT_BROKER_USERNAME: ${PACT_BROKER_USERNAME}
       PACT_BROKER_PASSWORD: ${PACT_BROKER_PASSWORD}
+      ffc-demo-web-TEST-VAR: ${ffc-demo-web-TEST-VAR}
     volumes:
       - ./test/integration:/home/node/test/integration
       - ./test/unit:/home/node/test/unit

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ffc-demo-web",
-  "version": "4.33.13",
+  "version": "4.33.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ffc-demo-web",
-      "version": "4.33.13",
+      "version": "4.33.14",
       "license": "OGL-UK-3.0",
       "dependencies": {
         "@hapi/catbox-redis": "6.0.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ffc-demo-web",
   "description": "Digital service mock to claim public money in the event property subsides into mine shaft.",
-  "version": "4.33.13",
+  "version": "4.33.14",
   "homepage": "https://github.com/DEFRA/ffc-demo-web",
   "repository": {
     "type": "git",

--- a/test/contract/debug.test.js
+++ b/test/contract/debug.test.js
@@ -1,10 +1,10 @@
 // test.js
-const assert = require('assert');
+const assert = require('assert')
 
-describe('Environment Variable Test', function() {
-  it('should print the environment variable', function() {
-    const envVar = process.env.MY_ENV_VAR;
-    console.log('Environment Variable:', envVar);
-    assert.ok(envVar, 'Environment variable is not set');
-  });
-});
+describe('Environment Variable Test', function () {
+  it('should print the environment variable', function () {
+    const envVar = process.env.MY_ENV_VAR
+    console.log('Environment Variable:', envVar)
+    assert.ok(envVar, 'Environment variable is not set')
+  })
+})

--- a/test/contract/debug.test.js
+++ b/test/contract/debug.test.js
@@ -3,7 +3,7 @@ const assert = require('assert')
 
 describe('Environment Variable Test', function () {
   it('should print the environment variable', function () {
-    const envVar = process.env.ffc-demo-web-TEST-VAR
+    const envVar = process.env.ffc_demo_web_TEST_VAR
     console.log('Environment Variable:', envVar)
     assert.ok(envVar, 'Environment variable is not set')
   })

--- a/test/contract/debug.test.js
+++ b/test/contract/debug.test.js
@@ -1,0 +1,10 @@
+// test.js
+const assert = require('assert');
+
+describe('Environment Variable Test', function() {
+  it('should print the environment variable', function() {
+    const envVar = process.env.MY_ENV_VAR;
+    console.log('Environment Variable:', envVar);
+    assert.ok(envVar, 'Environment variable is not set');
+  });
+});

--- a/test/contract/debug.test.js
+++ b/test/contract/debug.test.js
@@ -1,9 +1,9 @@
 // test.js
 const assert = require('assert')
+const envVar = process.env.ffc_demo_web_APPINSIGHTS_CONNECTIONSTRING
 
 describe('Environment Variable Test', function () {
   it('should print the environment variable', function () {
-    const envVar = process.env.ffc_demo_web_TEST_VAR
     console.log('Environment Variable:', envVar)
     assert.ok(envVar, 'Environment variable is not set')
   })

--- a/test/contract/debug.test.js
+++ b/test/contract/debug.test.js
@@ -1,6 +1,6 @@
 // test.js
 const assert = require('assert')
-const envVar = process.env.ffc_demo_web_APPINSIGHTS_CONNECTIONSTRING
+const envVar = `${process.env.ffc_demo_web_APPINSIGHTS_CONNECTIONSTRING}`
 
 describe('Environment Variable Test', function () {
   it('should print the environment variable', function () {

--- a/test/contract/debug.test.js
+++ b/test/contract/debug.test.js
@@ -3,7 +3,7 @@ const assert = require('assert')
 
 describe('Environment Variable Test', function () {
   it('should print the environment variable', function () {
-    const envVar = process.env.MY_ENV_VAR
+    const envVar = process.env.ffc-demo-web-TEST-VAR
     console.log('Environment Variable:', envVar)
     assert.ok(envVar, 'Environment variable is not set')
   })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
If this PR closes an issue, add '<[AB#213700](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/213700)>' somewhere in the PR summary. As a minimum, please *always* link to the relevant work items e.g. [AB#213700](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/213700) (work item number in Azure DevOps). Follow the format below carefully, guidance found here: https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops. Note: The Title pattern should be `{work item number}: {title}` -->

# **What this PR does / why we need it**:
*A brief description of changes being made*
*Link to the relevant work items: e.g: Relates to ADO Work Item [AB#213700](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/213700) and builds on #3376 (link to ADO Build ID URL)*

# **Special notes for your reviewer**
*Any specific actions or notes on review?*

# Testing
*Any relevant testing information and pipeline runs.*

# Checklist (please delete before completing or setting auto-complete)
- [ ] Story Work items associated (not Tasks)
- [ ] Successful testing run(s) link provided
- [ ] Title pattern should be `{work item number}: {title}`
- [ ] Description covers all the changes in the PR
- [ ] This PR contains documentation
- [ ] This PR contains tests

# Dependency check (tick or delete)
Have you updated any related templates, repositories or dependencies for new changes? We must ensure any dependencies like Software Templates are updated to include the latest changes to be scaffolded for all services where applicable.

- [ ] ADP Software Templates? - https://github.com/DEFRA/adp-software-templates
- [ ] ADP Portal Web API OR UI? https://github.com/DEFRA/adp-portal-api https://github.com/DEFRA/adp-portal 

# **How does this PR make you feel**:
![gif]([https://giphy.com/)
